### PR TITLE
Fix reproducibility issue

### DIFF
--- a/build.ml
+++ b/build.ml
@@ -56,7 +56,9 @@ let ml_srcs dir =
   | Some (m, e) when e = "ml" || e = "mli" -> f :: acc
   | Some _ | None -> acc
   in
-  Array.fold_left (add_file dir) [] (Sys.readdir dir)
+  let files = Sys.readdir dir in
+  Array.sort String.compare files;
+  Array.fold_left (add_file dir) [] files
 
 (* Finding and running commands *)
 


### PR DESCRIPTION
Reading a directory's content is not guaranteed to give the same order on different machines and compilation order will influence some global counters and cmti content, leading to differences in compiled files (constants named differently, hash differences in cmx files).

For more background of why this is important, see [https://reproducible-builds.org](https://reproducible-builds.org)

I use Guix as my distro and packaged cmdliner for it. I recently found that I had difficulties building odoc, which turned out to be a reproducibility issue in fmt (a hash was different in a cmx file), which in turn was due to a reproducibility issue in cmdliner. With diffoscope I was able to observe hash mismatches in cmdliner's cmx compiled from the exact same source, dependencies (bit-to-bit identical), environment variables, commands, options and from the same path. The cmti file contains command line arguments passed to the OCaml compiler, and that had differences in file order too.

I checked with disorderfs that this small change does indeed fix the reproducibility issue: running the build on a disorderfs without the change results in different builds, but with the patch, the result is bit-to-bit identical 100% of the time.

I'm not really an OCaml developper, so I might have made a mistake or not respected some style guideline. Feel free to reject this PR if that is the case and use a proper fix for that issue :)

Thanks!